### PR TITLE
Tetra Channel API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,12 @@
   "packages": {
     "": {
       "name": "tetr.js",
-      "version": "1.0.8",
+      "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^15.3.0",
         "@types/ws": "^7.4.4",
+        "axios": "^0.21.1",
         "events": "^3.3.0",
         "msgpack-lite": "^0.1.26",
         "node-fetch": "^2.6.1",
@@ -71,6 +72,14 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -145,6 +154,25 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/form-data": {
@@ -705,6 +733,14 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -763,6 +799,11 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@types/node": "^15.3.0",
     "@types/ws": "^7.4.4",
+    "axios": "^0.21.1",
     "events": "^3.3.0",
     "msgpack-lite": "^0.1.26",
     "node-fetch": "^2.6.1",

--- a/src/channel/Channel.ts
+++ b/src/channel/Channel.ts
@@ -1,0 +1,184 @@
+import { default as axios } from "axios";
+import type * as types from "./ChannelTypes";
+
+/**
+ * @description Some statistics about the service.
+ * @returns {Promise<types.generalStatsType>}
+ */
+
+async function generalStats(): Promise<types.generalStatsType> {
+  return await (await axios.get("https://ch.tetr.io/api/general/stats")).data;
+}
+
+/**
+ * @description A graph of user activity over the last 2 days. A user is seen as active if they logged in or received XP within the last 30 minutes.
+ * @returns {Promise<types.activityStatsType>}
+ */
+
+async function generalActivity(): Promise<types.activityStatsType> {
+  return await (await axios.get("https://ch.tetr.io/api/general/activity"))
+    .data;
+}
+
+/**
+ * @description An object describing the user in detail.
+ * @param {string} user The username of the user.
+ * @returns {Promise<types.userInfosType>}
+ */
+
+async function userInfos(user: string): Promise<types.userInfosType> {
+  return await (
+    await axios.get("https://ch.tetr.io/api/users/" + user.toLowerCase())
+  ).data;
+}
+
+/**
+ * @description An object describing the user in detail.
+ * @param {string} user The username of the user.
+ * @returns {Promise<types.UserRecordsType>}
+ */
+
+async function userRecords(user: string): Promise<types.userInfosType> {
+  return await (
+    await axios.get(
+      "https://ch.tetr.io/api/users/" + user.toLowerCase() + "/records"
+    )
+  ).data;
+}
+
+/**
+ * @description An array of users fulfilling the search criteria.
+ * @param {string} country
+ * @param {object} params
+ * @returns {Promise<types.LeaderboardType>}
+ */
+
+async function TL_Leaderboard(
+  country?: string,
+  params?: {
+    after?: number;
+    before?: number;
+    limit?: number;
+  }
+): Promise<types.LeaderboardType> {
+  return await (
+    await axios.get("https://ch.tetr.io/api/users/lists/league", {
+      params: {
+        ...params,
+        country,
+      },
+    })
+  ).data;
+}
+
+/**
+ * @description An array of all users fulfilling the search criteria. Please do not overuse this.
+ * @param {string} country
+ * @param {object} params
+ * @returns {Promise<types.LeaderboardType>}
+ */
+
+async function TL_Leaderboard_full(
+  country?: string
+): Promise<types.LeaderboardType> {
+  return await (
+    await axios.get("https://ch.tetr.io/api/users/lists/league/all", {
+      params: {
+        country,
+      },
+    })
+  ).data;
+}
+
+/**
+ * @description An array of users fulfilling the search criteria.
+ * @param {string} country
+ * @param {object} params
+ * @returns {Promise<types.LeaderboardType>}
+ */
+
+async function XP_Leaderboard(
+  country?: string,
+  params?: {
+    after?: number;
+    before?: number;
+    limit?: number;
+  }
+): Promise<types.LeaderboardType> {
+  return await (
+    await axios.get("https://ch.tetr.io/api/users/lists/xp", {
+      params: {
+        ...params,
+        country,
+      },
+    })
+  ).data;
+}
+
+/**
+ * The records in this Stream. A Stream is a list of records with a set length. Replays that are not featured in any Stream are automatically pruned.
+ * @param {string} stream
+ * @returns {Promise<types.StreamType>}
+ */
+
+async function stream(stream: string): Promise<types.StreamType> {
+  return await (await axios.get("https://ch.tetr.io/api/streams/" + stream))
+    .data;
+}
+
+/**
+ * The latest news items in any stream.
+ * @param {number} limit
+ * @returns {Promise<types.NewsListType>}
+ */
+
+async function all_news(limit?: number): Promise<types.NewsListType> {
+  return await (
+    await axios.get("https://ch.tetr.io/api/news/", { params: limit })
+  ).data;
+}
+
+/**
+ * The latest news items in the stream. Use stream "global" for the global news.
+ * @param {string} stream
+ * @param {number} limit
+ * @returns {Promise<types.NewsListType>}
+ */
+
+async function news(
+  stream: string,
+  limit?: number
+): Promise<types.NewsListType> {
+  return await (
+    await axios.get("https://ch.tetr.io/api/news/" + stream, { params: limit })
+  ).data;
+}
+
+var general = {
+  stats: generalStats,
+  activity: generalActivity,
+};
+
+var users = {
+  infos: userInfos,
+  records: userRecords,
+};
+
+var leaderboards = {
+  tetra_league: TL_Leaderboard,
+  tetra_league_full: TL_Leaderboard_full,
+  xp: XP_Leaderboard,
+};
+
+var misc = {
+  stream,
+  all_news,
+  news
+};
+
+export var TetraChannel = {
+  general,
+  users,
+  leaderboards,
+  misc,
+};

--- a/src/channel/ChannelTypes.ts
+++ b/src/channel/ChannelTypes.ts
@@ -1,0 +1,218 @@
+export type cache = {
+  status: string;
+  cached_at: number;
+  cached_until: number;
+};
+
+export type generalStatsType = {
+  success: boolean;
+  error?: string;
+  data?: {
+    usercount: number;
+    usercount_delta: number;
+    anoncount: number;
+    rankedcount: number;
+    replaycount: number;
+    gamesplayed: number;
+    gamesplayed_delta: number;
+    gamesfinished: number;
+    gametime: number;
+    inputs: number;
+    piecesplaced: number;
+  };
+  cache?: cache;
+};
+
+export type activityStatsType = {
+  success: boolean;
+  error?: string;
+  data?: {
+    activity: number[];
+  };
+  cache?: cache;
+};
+
+export type LeagueInfosType = {
+  gamesplayed: number;
+  gameswon: number;
+  rating: number;
+  glicko: number;
+  rd: number;
+  rank: string;
+  apm: number;
+  pps: number;
+  vs: number;
+};
+
+export type LeagueInfosFullType = {
+  gamesplayed: number;
+  gameswon: number;
+  rating: number;
+  glicko: number;
+  rd: number;
+  rank: string;
+  apm: number;
+  pps: number;
+  vs: number;
+  decaying: false;
+  standing: number;
+  percentile: number;
+  standing_local: number;
+  prev_rank: string;
+  prev_at: number;
+  next_rank: string;
+  next_at: number;
+  percentile_rank: number;
+};
+
+export type userInfosType = {
+  success: boolean;
+  error?: string;
+  data?: {
+    user: {
+      _id: string;
+      username: string;
+      role: string;
+      ts: string;
+      badges: {
+        id: string;
+        label: string;
+        ts: string;
+      }[];
+      xp: number;
+      gamesplayed: number;
+      gameswon: number;
+      gametime: number;
+      country: string;
+      supporter_tier: number;
+      verified: boolean;
+      league: LeagueInfosFullType;
+      avatar_revision: number;
+      friend_count: number;
+    };
+  };
+  cache?: cache;
+};
+
+export type recordType = {
+  record: {
+    _id: string;
+    stream: string;
+    replayid: string;
+    user: { _id: string; username: string };
+    ts: string;
+    endcontext: {
+      seed: number;
+      lines: number;
+      level_lines: number;
+      level_lines_needed: number;
+      inputs: number;
+      time: {
+        start: number;
+        zero: false;
+        locked: false;
+        prev: number;
+        frameoffset: number;
+      };
+      score: number;
+      zenlevel: number;
+      zenprogress: number;
+      level: number;
+      combo: number;
+      currentcombopower: number;
+      topcombo: number;
+      btb: number;
+      topbtb: number;
+      tspins: number;
+      piecesplaced: number;
+      clears: {
+        singles: number;
+        doubles: number;
+        triples: number;
+        quads: number;
+        realtspins: number;
+        minitspins: number;
+        minitspinsingles: number;
+        tspinsingles: number;
+        minitspindoubles: number;
+        tspindoubles: number;
+        tspintriples: number;
+        tspinquads: number;
+        allclear: number;
+      };
+      garbage: {
+        sent: number;
+        received: number;
+        attack: number;
+        cleared: number;
+      };
+      kills: number;
+      finesse: { combo: number; faults: number; perfectpieces: number };
+      finalTime: number;
+      gametype: string;
+    };
+    ismulti: false;
+  };
+  rank: number;
+};
+
+export type UserRecordsType = {
+  success: boolean;
+  error?: string;
+  data?: {
+    records: {
+      "40l": recordType;
+      blitz: recordType;
+    };
+    zen: {
+      level: number;
+      score: number;
+    };
+  };
+  cache?: cache;
+};
+
+export type Leaderboard_UserInfoType = {
+  _id: string;
+  username: string;
+  role: string;
+  country: string;
+  supporter: number;
+  verified: boolean;
+  league: LeagueInfosType;
+};
+
+export type LeaderboardType = {
+  success: boolean;
+  error?: string;
+  data?: {
+    users: Leaderboard_UserInfoType[];
+  };
+  cache?: cache;
+};
+
+export type StreamType = {
+  success: boolean;
+  error?: string;
+  data?: {
+    records: UserRecordsType[];
+  };
+  cache?: cache;
+};
+
+export type NewsType = {
+  _id: string;
+  stream: string;
+  type: string;
+  data: recordType;
+  ts: string;
+};
+
+export type NewsListType = {
+  success: boolean;
+  error?: string;
+  data?: {
+    news: NewsType[];
+  };
+  cache?: cache;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,9 @@ import ClientUser from "./client/ClientUser";
 import Room from "./room/Room";
 import User from "./user/User";
 import UserManager from "./user/UserManager";
+import { TetraChannel } from "./channel/Channel";
 
-export { Client, ClientUser, Room, User, UserManager };
+export { Client, ClientUser, Room, User, UserManager, TetraChannel };
 
 export interface Handling {
   arr: number;


### PR DESCRIPTION
Added the Tetra Channel API in the wrapper.

## Tetra Channel API
Any response from any request is the same that on [TETR.IO's API documentation](https://tetr.io/about/api). Every feature of the Tetra channel API is implemented to this wrapper.

### Requests list
```js
const { TetraChannel } = require("tetr.js");

// Requests about general stats

TetraChannel.general.stats().then(console.log)
TetraChannel.general.activity().then(console.log)

// Requests about users

TetraChannel.users.infos("thatcookie").then(console.log)
TetraChannel.users.records("thatcookie").then(console.log)

// Requests about leaderboards

TetraChannel.leaderboards.tetra_league("FR").then(console.log)
TetraChannel.leaderboards.tetra_league_full("FR").then(console.log)
TetraChannel.leaderboards.xp("FR").then(console.log)

// Miscallenous requests

TetraChannel.misc.all_news(15).then(console.log)
TetraChannel.misc.news("blitz_global", 15).then(console.log)
TetraChannel.misc.stream("40l_global").then(console.log)

```